### PR TITLE
Update options.js

### DIFF
--- a/chrome/content/zotero-report-customizer/options.js
+++ b/chrome/content/zotero-report-customizer/options.js
@@ -57,8 +57,11 @@ function initializePrefs() {
         var _field_cell = elt(_field_row, 'treecell', {editable: 'false', label: field.label});
       }
     }
-
-    var fields = [  'title', 'firstCreator', 'date', 'accessed', 'dateAdded', 'dateModified', 'publicationTitle', 'publisher',
+    // I added 'extra' to the sort menu
+    // I also had to manually update the key @Preferences Menu, Advanced, Miscellaneous, Open about:config
+    // Key to update: extensions.zotero-report-customizer.sort
+    // To the beginning of the key array, I added after the "[": {"name":"extra","order":"a"},
+    var fields = [  'extra', 'title', 'firstCreator', 'date', 'accessed', 'dateAdded', 'dateModified', 'publicationTitle', 'publisher',
                     'itemType', 'series', 'type', 'medium', 'callNumber', 'pages', 'archiveLocation', 'DOI', 'ISBN', 'ISSN',
                     'edition', 'url', 'rights' ];
     // load stored order


### PR DESCRIPTION
I changed the original options.js file line 61 (now line 65) to include 'extra' as a sort option on the menu.

I also had to manually update the key @Preferences Menu, Advanced, Miscellaneous, Open about:config
Key to update: extensions.zotero-report-customizer.sort
To the beginning of the key array, I added after the "[": {"name":"extra","order":"a"},
So now my whole key is:
[{"name":"extra","order":"a"},{"name":"dateModified"},{"name":"firstCreator"},{"name":"title"},{"name":"pages"},{"name":"date"},{"name":"accessed"},{"name":"dateAdded"},{"name":"publicationTitle"},{"name":"publisher"},{"name":"itemType"},{"name":"series"},{"name":"type"},{"name":"medium"},{"name":"callNumber"},{"name":"archiveLocation"},{"name":"DOI"},{"name":"ISBN"},{"name":"ISSN"},{"name":"edition"},{"name":"url"},{"name":"rights"}]

Maybe there's a way to automate updating the key, but this work-around got me on my way.
