### PR TITLE
Update README.md with where to find "Report Customizer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ bibtex key plus any conflicts between them.
 
 ## Customizing the fields to display
 
+In Zotero stand-alone, click on the gear menu, and then select "Report Customizer...". 
 The default is to display everything, and by default, all possible fields will have a checkmark set before them. If you remove the checkmark,
 that field will not show up on the report. The fields are grouped per item type, but many of the fields are present in most of the itemtypes; if you
 untick 'Title', it will untick them for *all* item types, as 'Title' is present in them all.
 
 ## Customizing the sort order
 
+In Zotero stand-alone, click on the gear menu, and then select "Report Customizer...".
 By default, Zotero orders reports for collections in whatever order they are sorted in your library, on title by default. The second tab of the
 Resport Customizer config screen allows you to override this order. You can click the fields in order to change their sorting behavior
 (ascending, descending, or not involved), and you can drag and drop the fields to change the grouping of the sort. If all fields are set to "not involved",


### PR DESCRIPTION
I downloaded the plug-in, but I couldn't find the report customizer. Hopefully this is a helpful addition to the documentation!